### PR TITLE
Move AZURE non compatible filters

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/disk.py
+++ b/tools/c7n_azure/c7n_azure/resources/disk.py
@@ -1,6 +1,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
+import dateutil
+import distutils
+from c7n.filters import Filter
+from c7n.utils import type_schema
 from c7n_azure.resources.arm import ArmResourceManager
 from c7n_azure.provider import resources
 
@@ -39,3 +44,37 @@ class Disk(ArmResourceManager):
             'sku.name'
         )
         resource_type = 'Microsoft.Compute/disks'
+
+
+@Disk.filter_registry.register('snapshots')
+class DiskSnapshotsFilter(Filter):
+
+    schema = type_schema(
+        'snapshots',
+        **{'exist': {'anyOf': [{'type': 'boolean'}, {'type': 'string'}]},
+           'max-age': {'type': 'integer', 'minimum': 1},
+           'required': ['exist', 'max-age']}
+    )
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.compute.ComputeManagementClient')
+
+        expecting_exist = self.data['exist']
+        expecting_max_age = self.data['max-age']
+        now = datetime.datetime.now(tz=dateutil.tz.tzutc())
+        filtered_resources = []
+        snapshots = [snapshot for snapshot in client.snapshots.list()]
+        for resource in resources:
+            add_to_filtered = False
+            for snapshot in snapshots:
+                if (resource['id'].lower() == snapshot.creation_data.source_resource_id.lower()
+                        and (now - snapshot.time_created).days < expecting_max_age):
+                    add_to_filtered = True
+                    break
+
+            if (isinstance(expecting_exist, bool) and add_to_filtered == expecting_exist) or \
+                    (isinstance(expecting_exist, str) and
+                     add_to_filtered == distutils.util.strtobool(expecting_exist)):
+                filtered_resources.append(resource)
+
+        return filtered_resources

--- a/tools/c7n_azure/c7n_azure/resources/resource_map.py
+++ b/tools/c7n_azure/c7n_azure/resources/resource_map.py
@@ -89,6 +89,8 @@ ResourceMap = {
     "azure.spring-service-instance": "c7n_azure.resources.spring.SpringServiceInstance",
     "azure.sql-database": "c7n_azure.resources.sqldatabase.SqlDatabase",
     "azure.sqldatabase": "c7n_azure.resources.sqldatabase.SqlDatabase",
+    "azure.sql-managed-instance": "c7n_azure.resources.sqlmanagedinstance.SqlManagedInstance",
+    "azure.sqlmanagedinstance": "c7n_azure.resources.sqlmanagedinstance.SqlManagedInstance",
     "azure.sql-server": "c7n_azure.resources.sqlserver.SqlServer",
     "azure.sqlserver": "c7n_azure.resources.sqlserver.SqlServer",
     "azure.storage": "c7n_azure.resources.storage.Storage",

--- a/tools/c7n_azure/c7n_azure/resources/sqlmanagedinstance.py
+++ b/tools/c7n_azure/c7n_azure/resources/sqlmanagedinstance.py
@@ -1,0 +1,219 @@
+import distutils
+import logging
+
+from c7n_azure.filters import ValueFilter
+from c7n_azure.provider import resources
+from c7n_azure.resources.arm import ArmResourceManager
+from c7n.filters import Filter
+from c7n.utils import type_schema
+
+log = logging.getLogger('custodian.azure.sql-managed-instance')
+
+
+@resources.register('sql-managed-instance', aliases=['sqlmanagedinstance'])
+class SqlManagedInstance(ArmResourceManager):
+
+    class resource_type(ArmResourceManager.resource_type):
+        doc_groups = ['Instances']
+
+        service = 'azure.mgmt.sql'
+        client = 'SqlManagementClient'
+        enum_spec = ('managed_instances', 'list', None)
+        resource_type = 'Microsoft.Sql/managedInstances'
+        diagnostic_settings_enabled = False
+
+
+@SqlManagedInstance.filter_registry.register('vulnerability-assessments')
+class SqlManagedInstanceVulnerabilityAssessmentsFilter(Filter):
+    """
+    Filters resources by vulnerability assessments.
+
+    :example:
+
+    .. code-block:: yaml
+
+    policies:
+      - name: azure-sql-managed-instance-vulnerability-assessments
+        resource: azure.sql-managed-instance
+        filters:
+          - type: vulnerability-assessments
+            key: recurring_scans.is_enabled
+            value: true
+    """
+
+    schema = type_schema(
+        'vulnerability-assessments', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def filter_by_assessments(assessments, filtering_properties, value):
+        add_to_filtered = False
+        for assessment in assessments:
+            assessment = assessment.as_dict()
+            property_value = assessment
+            for filtering_property in filtering_properties:
+                if filtering_property in property_value:
+                    property_value = property_value[filtering_property]
+                else:
+                    property_value = None
+                    break
+            if type(property_value) is bool and type(value) is str:
+                value = distutils.util.strtobool(value)
+            if value == property_value:
+                add_to_filtered = True
+                break
+        return add_to_filtered
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.sql.SqlManagementClient')
+
+        filtered_resources = []
+        key = self.data['key']
+        value = self.data['value']
+        filtering_properties = key.split('.')
+        for resource in resources:
+            assessments = client.managed_instance_vulnerability_assessments.list_by_instance(
+                resource['resourceGroup'],
+                resource['name']
+            )
+            add_to_filtered = self.filter_by_assessments(assessments, filtering_properties, value)
+            if add_to_filtered:
+                filtered_resources.append(resource)
+
+        return super(SqlManagedInstanceVulnerabilityAssessmentsFilter, self).process(
+            filtered_resources, event)
+
+
+@SqlManagedInstance.filter_registry.register('encryption-protector')
+class SqlManagedInstanceEncryptionProtectorsFilter(Filter):
+    """
+    Filters resources by encryption protectors.
+
+    :example:
+
+    .. code-block:: yaml
+
+    policies:
+      - name: azure-sql-managed-instance-service-managed
+        resource: azure.sql-managed-instance
+        filters:
+          - type: encryption-protector
+            key: kind
+            value: servicemanaged
+    """
+
+    schema = type_schema(
+        'encryption-protector', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def filter_by_encryption_protector(protectors, filtering_properties, value):
+        add_to_filtered = False
+        for protector in protectors:
+            protector = protector.as_dict()
+            property_value = protector
+            for filtering_property in filtering_properties:
+                if filtering_property in property_value:
+                    property_value = property_value[filtering_property]
+                else:
+                    property_value = None
+                    break
+            if type(property_value) is bool and type(value) is str:
+                value = distutils.util.strtobool(value)
+            if value == property_value:
+                add_to_filtered = True
+                break
+        return add_to_filtered
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.sql.SqlManagementClient')
+
+        filtered_resources = []
+        key = self.data['key']
+        value = self.data['value']
+        filtering_properties = key.split('.')
+        for resource in resources:
+            protectors = client.managed_instance_encryption_protectors.list_by_instance(
+                resource['resourceGroup'],
+                resource['name']
+            )
+            add_to_filtered = self.filter_by_encryption_protector(
+                protectors, filtering_properties, value)
+
+            if add_to_filtered:
+                filtered_resources.append(resource)
+
+        return super(SqlManagedInstanceEncryptionProtectorsFilter, self).process(
+            filtered_resources, event)
+
+
+@SqlManagedInstance.filter_registry.register('managed-server-security-alert-policies')
+class SqlManagedInstanceSecurityAlertPoliciesFilter(Filter):
+    """
+    Filters resources by managed server security alert policies'.
+
+    :example:
+
+    .. code-block:: yaml
+
+    policies:
+      - name: azure-sql-managed-server-security-alert-policies
+        resource: azure.sql-managed-instance
+        filters:
+          - type: managed-server-security-alert-policies
+            key: state
+            value: Disabled
+    """
+
+    schema = type_schema(
+        'managed-server-security-alert-policies', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def filter_by_security_alert_policies(security_alert_policies, filtering_properties, value):
+        add_to_filtered = False
+        for security_alert_policy in security_alert_policies:
+            security_alert_policy = security_alert_policy.as_dict()
+            property_value = security_alert_policy
+            for filtering_property in filtering_properties:
+                if filtering_property in property_value:
+                    property_value = property_value[filtering_property]
+                else:
+                    property_value = None
+                    break
+            if type(property_value) is bool and type(value) is str:
+                value = distutils.util.strtobool(value)
+            if value == property_value:
+                add_to_filtered = True
+                break
+        return add_to_filtered
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.sql.SqlManagementClient')
+
+        filtered_resources = []
+        key = self.data['key']
+        value = self.data['value']
+        filtering_properties = key.split('.')
+        for resource in resources:
+            security_alert_policies = (
+                client.managed_server_security_alert_policies.list_by_instance(
+                    resource['resourceGroup'],
+                    resource['name']))
+            add_to_filtered = self.filter_by_security_alert_policies(
+                security_alert_policies, filtering_properties, value)
+
+            if add_to_filtered:
+                filtered_resources.append(resource)
+
+        return super(SqlManagedInstanceSecurityAlertPoliciesFilter, self).process(
+            filtered_resources, event)

--- a/tools/c7n_azure/c7n_azure/resources/vnet.py
+++ b/tools/c7n_azure/c7n_azure/resources/vnet.py
@@ -1,8 +1,11 @@
 # Copyright The Cloud Custodian Authors.
 # SPDX-License-Identifier: Apache-2.0
 
+from c7n_azure.filters import ValueFilter
 from c7n_azure.provider import resources
 from c7n_azure.resources.arm import ArmResourceManager
+from c7n.filters import Filter
+from c7n.utils import type_schema
 
 
 @resources.register('vnet')
@@ -33,3 +36,125 @@ class Vnet(ArmResourceManager):
         client = 'NetworkManagementClient'
         enum_spec = ('virtual_networks', 'list_all', None)
         resource_type = 'Microsoft.Network/virtualNetworks'
+
+
+@Vnet.filter_registry.register('subnet-application-gateway-vnet-filter')
+class SubnetApplicationGatewayVnetFilter(Filter):
+
+    schema = type_schema(
+        'subnet-application-gateway-vnet-filter',
+    )
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client()
+        self.application_gateways = client.application_gateways.list_all()
+        filtered_resources = []
+        for vnet in resources:
+            for subnet_id in vnet['properties']['subnets']:
+                if self._mapping_resources(subnet_id['id']):
+                    filtered_resources.append(vnet)
+                    break
+        return filtered_resources
+
+    def _mapping_resources(self, subnet_id):
+        for application_gateway in self.application_gateways:
+            for subnet in application_gateway.gateway_ip_configurations:
+                if subnet.subnet.id == subnet_id:
+                    return True
+        return False
+
+
+@Vnet.filter_registry.register('network-interface-assignment')
+class NetworkInterfaceAssignmentFilter(Filter):
+    """
+    Filters resources by network interface assignments.
+
+    Available values:
+    - present (checks if a field is present),
+    - absent (checks if a field is absent),
+    - not-null (checks if a field is not null),
+    - empty (checks if a field is empty),
+    - regular value (compare with a value)
+
+    :example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: vnet-network-interface-assignment-filter
+            resource: azure.vnet
+            filters:
+              - type: network-interface-assignment
+                key: virtual_machine
+                value: present
+    """
+
+    schema = type_schema(
+        'network-interface-assignment', rinherit=ValueFilter.schema
+    )
+
+    def __call__(self, resource):
+        return resource
+
+    @staticmethod
+    def __network_interfaces_to_map(network_interfaces):
+        network_interfaces_map = {}
+        for network_interface in network_interfaces:
+            network_interface_dict = network_interface.as_dict()
+            ip_configurations = network_interface_dict.get("ip_configurations")
+            for ip_configuration in ip_configurations:
+                if ip_configuration.get("primary"):
+                    network_interfaces_map[ip_configuration.get("id")] = network_interface_dict
+                    break
+        return network_interfaces_map
+
+    @staticmethod
+    def __match(object_value, data_value):
+        if object_value is None and data_value == 'absent':
+            return True
+        elif object_value is not None and data_value == 'present':
+            return True
+        elif data_value == 'not-null' and object_value:
+            return True
+        elif data_value == 'empty' and not object_value:
+            return True
+        elif object_value == data_value:
+            return True
+
+        return False
+
+    def __data_value_matches_value_in_network_interface(
+            self, ip_configurations, network_interfaces_map, data_key, data_value):
+        valid = False
+        for ip_configuration in ip_configurations:
+            ip_configuration_id = ip_configuration.get("id")
+            if ip_configuration_id is not None:
+                network_interface = network_interfaces_map.get(ip_configuration_id)
+                if network_interface is not None:
+                    object_value = network_interface.get(data_key)
+                    if self.__match(object_value, data_value):
+                        valid = True
+                        break
+        return valid
+
+    def process(self, resources, event=None):
+        client = self.manager.get_client('azure.mgmt.network.NetworkManagementClient')
+
+        filtered_resources = []
+        data_key = self.data['key']
+        data_value = self.data['value']
+
+        network_interfaces = client.network_interfaces.list_all()
+        network_interfaces_map = self.__network_interfaces_to_map(network_interfaces)
+
+        for resource in resources:
+            subnets = resource.get("properties").get("subnets", [])
+            for subnet in subnets:
+                ip_configurations = subnet.get("properties").get("ipConfigurations", [])
+                add_to_filtered = self.__data_value_matches_value_in_network_interface(
+                    ip_configurations, network_interfaces_map, data_key, data_value)
+                if add_to_filtered:
+                    filtered_resources.append(resource)
+
+        return super(NetworkInterfaceAssignmentFilter, self).process(
+            filtered_resources, event)

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -242,6 +242,8 @@ class Session:
             # 2020-06-01 is not supported, but 2019-11-01 is working as expected.
             if client == 'azure.mgmt.costmanagement.CostManagementClient':
                 client_args['raw_request_hook'] = cost_query_override_api_version
+            elif client == 'azure.mgmt.security.SecurityCenter':
+                client_args['asc_location'] = ''
 
             if 'subscription_id' in klass_parameters:
                 client_args['subscription_id'] = self.subscription_id

--- a/tools/c7n_azure/tests_azure/cassettes/DiskTest.test_disk_without_snapshots.json
+++ b/tools/c7n_azure/tests_azure/cassettes/DiskTest.test_disk_without_snapshots.json
@@ -1,0 +1,170 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/disks?api-version=2019-07-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Mon, 22 Mar 2021 17:47:37 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;239,Microsoft.Compute/HighCostGet30Min;1916"
+                    ],
+                    "content-length": [
+                        "2399"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "cctestvm_disk2_a9097edcfa664ff48c8e88e87d72003e",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK/providers/Microsoft.Compute/disks/cctestvm_disk2_a9097edcfa664ff48c8e88e87d72003e",
+                                "type": "Microsoft.Compute/disks",
+                                "location": "southcentralus",
+                                "tags": {
+                                    "testtag": "testvalue"
+                                },
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Empty"
+                                    },
+                                    "diskSizeGB": 1023,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "encryption": {
+                                        "type": "EncryptionAtRestWithPlatformKey"
+                                    },
+                                    "timeCreated": "2021-03-22T15:57:44.1838953+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached",
+                                    "diskSizeBytes": 1098437885952,
+                                    "uniqueId": "cd87766e-14f2-46db-85fc-081650bb0161"
+                                }
+                            },
+                            {
+                                "name": "cctestvm_OsDisk_1_81338ced63fa4855b8a5f3e2bab5213c",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK/providers/Microsoft.Compute/disks/cctestvm_OsDisk_1_81338ced63fa4855b8a5f3e2bab5213c",
+                                "type": "Microsoft.Compute/disks",
+                                "location": "southcentralus",
+                                "tags": {
+                                    "testtag": "testvalue"
+                                },
+                                "sku": {
+                                    "name": "Standard_LRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "osType": "Linux",
+                                    "hyperVGeneration": "V1",
+                                    "creationData": {
+                                        "createOption": "FromImage",
+                                        "imageReference": {
+                                            "id": "/Subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/Providers/Microsoft.Compute/Locations/southcentralus/Publishers/Canonical/ArtifactTypes/VMImage/Offers/UbuntuServer/Skus/16.04.0-LTS/Versions/16.04.201802220"
+                                        }
+                                    },
+                                    "diskSizeGB": 30,
+                                    "diskIOPSReadWrite": 500,
+                                    "diskMBpsReadWrite": 60,
+                                    "encryption": {
+                                        "type": "EncryptionAtRestWithPlatformKey"
+                                    },
+                                    "timeCreated": "2021-03-22T15:57:44.3739064+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached",
+                                    "diskSizeBytes": 32212254720,
+                                    "uniqueId": "84f4ad69-4e6c-4f79-8793-4b8761b43774"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/snapshots?api-version=2019-07-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Mon, 22 Mar 2021 17:47:43 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;238,Microsoft.Compute/HighCostGet30Min;1915"
+                    ],
+                    "content-length": [
+                        "1155"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "snapshot-1",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_DISK/providers/Microsoft.Compute/snapshots/snapshot-1",
+                                "type": "Microsoft.Compute/snapshots",
+                                "location": "southcentralus",
+                                "tags": {},
+                                "sku": {
+                                    "name": "Standard_ZRS",
+                                    "tier": "Standard"
+                                },
+                                "properties": {
+                                    "creationData": {
+                                        "createOption": "Copy",
+                                        "sourceResourceId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_disk/providers/Microsoft.Compute/disks/cctestvm_disk2_a9097edcfa664ff48c8e88e87d72003e",
+                                        "sourceUniqueId": "cd87766e-14f2-46db-85fc-081650bb0161"
+                                    },
+                                    "diskSizeGB": 1023,
+                                    "encryption": {
+                                        "type": "EncryptionAtRestWithPlatformKey"
+                                    },
+                                    "incremental": false,
+                                    "timeCreated": "2021-03-22T15:59:55.6000972+00:00",
+                                    "provisioningState": "Succeeded",
+                                    "diskState": "Unattached",
+                                    "diskSizeBytes": 1098437885952,
+                                    "uniqueId": "7fce9664-c24e-4f74-b6f0-3133b41d55f9"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_encryption_protector.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_encryption_protector.json
@@ -1,0 +1,121 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 24 Sep 2021 13:43:22 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "1276"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "068ac866-15e5-4bc3-96fa-495482496d96",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "testsqlmi71.71ccd8863ff8.database.windows.net",
+                                    "administratorLogin": "testadm71",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Network/virtualNetworks/vnet-testsqlmi71/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "71ccd8863ff8",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71",
+                                "name": "testsqlmi71",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/encryptionProtector?api-version=2017-10-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "date": [
+                        "Fri, 24 Sep 2021 13:43:23 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "358"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "kind": "servicemanaged",
+                                "properties": {
+                                    "serverKeyName": "ServiceManaged",
+                                    "serverKeyType": "ServiceManaged"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/encryptionProtector/current",
+                                "name": "current",
+                                "type": "Microsoft.Sql/managedInstances/encryptionProtector"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_recurring_scans.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_filter_recurring_scans.json
@@ -1,0 +1,126 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Fri, 24 Sep 2021 13:13:07 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1276"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "068ac866-15e5-4bc3-96fa-495482496d96",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "testsqlmi71.71ccd8863ff8.database.windows.net",
+                                    "administratorLogin": "testadm71",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Network/virtualNetworks/vnet-testsqlmi71/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "71ccd8863ff8",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71",
+                                "name": "testsqlmi71",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/vulnerabilityAssessments?api-version=2018-06-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Fri, 24 Sep 2021 13:13:17 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "485"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "storageContainerPath": "https://sqlva43wdauneefhes.blob.core.windows.net/vulnerability-assessment/",
+                                    "recurringScans": {
+                                        "isEnabled": true,
+                                        "emailSubscriptionAdmins": true,
+                                        "emails": [
+                                            "volodymyr_vrydnyk@epam.com"
+                                        ]
+                                    }
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/sqlmirg/providers/Microsoft.Sql/managedInstances/testsqlmi71/vulnerabilityAssessments/Default",
+                                "name": "Default",
+                                "type": "Microsoft.Sql/managedInstances/vulnerabilityAssessments"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance.json
@@ -1,0 +1,77 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 21 Sep 2021 15:39:04 GMT"
+                    ],
+                    "content-length": [
+                        "1264"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "185f2516-c869-4aae-b485-40cb4190b515",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "vvtestmisql.6fb8019adb20.database.windows.net",
+                                    "administratorLogin": "vvadmin",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/virtualNetworks/vnet-vvtestmisql/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "6fb8019adb20",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvtestmisql",
+                                "name": "vvtestmisql",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance_security_alert_policies.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_instance_security_alert_policies.json
@@ -1,0 +1,77 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Tue, 21 Sep 2021 15:42:15 GMT"
+                    ],
+                    "content-length": [
+                        "1264"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "185f2516-c869-4aae-b485-40cb4190b515",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "vvtestmisql.6fb8019adb20.database.windows.net",
+                                    "administratorLogin": "vvadmin",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/virtualNetworks/vnet-vvtestmisql/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "6fb8019adb20",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {},
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvtestmisql",
+                                "name": "vvtestmisql",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_server_security_alert_policies.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SqlManagedInstanceTest.test_sql_managed_server_security_alert_policies.json
@@ -1,0 +1,132 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Sql/managedInstances?api-version=2020-02-02-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Wed, 29 Sep 2021 10:21:48 GMT"
+                    ],
+                    "content-length": [
+                        "1261"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "identity": {
+                                    "principalId": "7153dfac-8387-49e3-87fc-0dd44059a248",
+                                    "type": "SystemAssigned",
+                                    "tenantId": "00000000-0000-0000-0000-000000000003"
+                                },
+                                "sku": {
+                                    "name": "GP_Gen5",
+                                    "tier": "GeneralPurpose",
+                                    "family": "Gen5",
+                                    "capacity": 4
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "fullyQualifiedDomainName": "vvsqlmi1.4b120597217c.database.windows.net",
+                                    "administratorLogin": "vvadm",
+                                    "subnetId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/virtualNetworks/vnet-vvsqlmi1/subnets/ManagedInstance",
+                                    "state": "Ready",
+                                    "licenseType": "LicenseIncluded",
+                                    "vCores": 4,
+                                    "storageSizeInGB": 32,
+                                    "collation": "SQL_Latin1_General_CP1_CI_AS",
+                                    "dnsZone": "4b120597217c",
+                                    "publicDataEndpointEnabled": false,
+                                    "proxyOverride": "Proxy",
+                                    "timezoneId": "UTC",
+                                    "maintenanceConfigurationId": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Maintenance/publicMaintenanceConfigurations/SQL_Default",
+                                    "privateEndpointConnections": [],
+                                    "minimalTlsVersion": "1.2",
+                                    "storageAccountType": "LRS",
+                                    "zoneRedundant": false
+                                },
+                                "location": "eastus",
+                                "tags": {
+                                    "VV": "test"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvsqlmi1",
+                                "name": "vvsqlmi1",
+                                "type": "Microsoft.Sql/managedInstances"
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvsqlmi1/securityAlertPolicies?api-version=2017-03-01-preview",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Wed, 29 Sep 2021 10:21:48 GMT"
+                    ],
+                    "content-length": [
+                        "463"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "properties": {
+                                    "state": "Disabled",
+                                    "disabledAlerts": [
+                                        ""
+                                    ],
+                                    "emailAddresses": [
+                                        ""
+                                    ],
+                                    "emailAccountAdmins": false,
+                                    "storageEndpoint": "",
+                                    "storageAccountAccessKey": "",
+                                    "retentionDays": 0,
+                                    "creationTime": "2021-09-29T10:07:55.11Z"
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Sql/managedInstances/vvsqlmi1/securityAlertPolicies/Default",
+                                "name": "Default",
+                                "type": "Microsoft.Sql/managedInstances/securityAlertPolicies"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SubnetApplicationGatewayTest.test_subnet_application_gateway_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SubnetApplicationGatewayTest.test_subnet_application_gateway_filter.json
@@ -1,0 +1,645 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/virtualNetworks?api-version=2019-11-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-ms-arm-service-request-id": [
+                        "68defbae-4641-4c59-a3b4-b0f43fa88dd3"
+                    ],
+                    "date": [
+                        "Thu, 05 Aug 2021 12:46:25 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "16423"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "176_vnet_green",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/virtualNetworks/176_vnet_green",
+                                "etag": "W/\"ec823c6c-36ec-46ad-bd3a-24d2c0c91f2f\"",
+                                "type": "Microsoft.Network/virtualNetworks",
+                                "location": "eastus",
+                                "tags": {
+                                    "ComplianceStatus": "Green",
+                                    "CustodianRule": "epam-azure-176-asb_ddos_protection_enabled"
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "ce3f65e1-ad9d-44e1-b250-96299b2da7bb",
+                                    "addressSpace": {
+                                        "addressPrefixes": [
+                                            "10.0.0.0/16"
+                                        ]
+                                    },
+                                    "dhcpOptions": {
+                                        "dnsServers": []
+                                    },
+                                    "subnets": [
+                                        {
+                                            "name": "appgtwgreen",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/virtualNetworks/176_vnet_green/subnets/appgtwgreen",
+                                            "etag": "W/\"ec823c6c-36ec-46ad-bd3a-24d2c0c91f2f\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "addressPrefix": "10.0.1.0/24",
+                                                "applicationGatewayIPConfigurations": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/gatewayIPConfigurations/176_gtw_ip_conf_green"
+                                                    }
+                                                ],
+                                                "serviceEndpoints": [],
+                                                "delegations": [],
+                                                "privateEndpointNetworkPolicies": "Enabled",
+                                                "privateLinkServiceNetworkPolicies": "Enabled"
+                                            },
+                                            "type": "Microsoft.Network/virtualNetworks/subnets"
+                                        }
+                                    ],
+                                    "virtualNetworkPeerings": [],
+                                    "enableDdosProtection": true,
+                                    "ddosProtectionPlan": {
+                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/ddosProtectionPlans/176-ddos_prot_plan"
+                                    }
+                                }
+                            },
+                            {
+                                "name": "176_vnet_red",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/virtualNetworks/176_vnet_red",
+                                "etag": "W/\"1b4cde3a-4f4e-4b4a-b7a1-ffd24c9ee346\"",
+                                "type": "Microsoft.Network/virtualNetworks",
+                                "location": "eastus",
+                                "tags": {
+                                    "ComplianceStatus": "Red",
+                                    "CustodianRule": "epam-azure-176-asb_ddos_protection_enabled"
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "6df79b48-edb2-49be-85b2-345862e5f538",
+                                    "addressSpace": {
+                                        "addressPrefixes": [
+                                            "10.0.0.0/16"
+                                        ]
+                                    },
+                                    "dhcpOptions": {
+                                        "dnsServers": []
+                                    },
+                                    "subnets": [
+                                        {
+                                            "name": "appgtwgred",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/virtualNetworks/176_vnet_red/subnets/appgtwgred",
+                                            "etag": "W/\"1b4cde3a-4f4e-4b4a-b7a1-ffd24c9ee346\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "addressPrefix": "10.0.1.0/24",
+                                                "applicationGatewayIPConfigurations": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/gatewayIPConfigurations/176_gtw_ip_conf_red"
+                                                    }
+                                                ],
+                                                "serviceEndpoints": [],
+                                                "delegations": [],
+                                                "privateEndpointNetworkPolicies": "Enabled",
+                                                "privateLinkServiceNetworkPolicies": "Enabled"
+                                            },
+                                            "type": "Microsoft.Network/virtualNetworks/subnets"
+                                        }
+                                    ],
+                                    "virtualNetworkPeerings": [],
+                                    "enableDdosProtection": false
+                                }
+                            },
+                            {
+                                "name": "aks-vnet-41463261",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Network/virtualNetworks/aks-vnet-41463261",
+                                "etag": "W/\"1facb18a-9e7a-48af-af29-9bc32d488a2b\"",
+                                "type": "Microsoft.Network/virtualNetworks",
+                                "location": "eastus",
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "99ec1b44-8fa6-4cf7-a878-b590ecd863cd",
+                                    "addressSpace": {
+                                        "addressPrefixes": [
+                                            "10.0.0.0/8"
+                                        ]
+                                    },
+                                    "subnets": [
+                                        {
+                                            "name": "aks-subnet",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Network/virtualNetworks/aks-vnet-41463261/subnets/aks-subnet",
+                                            "etag": "W/\"1facb18a-9e7a-48af-af29-9bc32d488a2b\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "addressPrefix": "10.240.0.0/16",
+                                                "networkSecurityGroup": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Network/networkSecurityGroups/aks-agentpool-41463261-nsg"
+                                                },
+                                                "ipConfigurations": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig1"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig2"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig3"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig4"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig5"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig6"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig7"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig8"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig9"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig10"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig11"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig12"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig13"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig14"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig15"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig16"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig17"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig18"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig19"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig20"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig21"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig22"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig23"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig24"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig25"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig26"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig27"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig28"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig29"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig30"
+                                                    },
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/MC_Test12-rg_Test12AKSCluster_eastus/providers/Microsoft.Compute/virtualMachineScaleSets/aks-default-41463261-vmss/virtualMachines/0/networkInterfaces/aks-default-41463261-vmss/ipConfigurations/ipconfig31"
+                                                    }
+                                                ],
+                                                "delegations": [],
+                                                "privateEndpointNetworkPolicies": "Enabled",
+                                                "privateLinkServiceNetworkPolicies": "Enabled"
+                                            },
+                                            "type": "Microsoft.Network/virtualNetworks/subnets"
+                                        }
+                                    ],
+                                    "virtualNetworkPeerings": [],
+                                    "enableDdosProtection": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/applicationGateways?api-version=2019-11-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "x-ms-arm-service-request-id": [
+                        "923792d1-4fab-45d7-90eb-e16f69f46211"
+                    ],
+                    "date": [
+                        "Thu, 05 Aug 2021 12:46:25 GMT"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "18673"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "176_app_gateway_green",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green",
+                                "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                "type": "Microsoft.Network/applicationGateways",
+                                "location": "eastus",
+                                "tags": {
+                                    "ComplianceStatus": "Green",
+                                    "CustodianRule": "epam-azure-176-asb_ddos_protection_enabled"
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "f2ff253a-2833-428b-ba7e-c8fc31c6030e",
+                                    "sku": {
+                                        "name": "Standard_Small",
+                                        "tier": "Standard",
+                                        "capacity": 2
+                                    },
+                                    "operationalState": "Running",
+                                    "gatewayIPConfigurations": [
+                                        {
+                                            "name": "176_gtw_ip_conf_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/gatewayIPConfigurations/176_gtw_ip_conf_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "subnet": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/virtualNetworks/176_vnet_green/subnets/appgtwgreen"
+                                                }
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"
+                                        }
+                                    ],
+                                    "sslCertificates": [],
+                                    "authenticationCertificates": [],
+                                    "frontendIPConfigurations": [
+                                        {
+                                            "name": "176_front_ip_conf_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/frontendIPConfigurations/176_front_ip_conf_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "privateIPAllocationMethod": "Dynamic",
+                                                "publicIPAddress": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/publicIPAddresses/176_pip_green"
+                                                },
+                                                "httpListeners": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/httpListeners/176_http_listener_green"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ],
+                                    "frontendPorts": [
+                                        {
+                                            "name": "176_front_port_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/frontendPorts/176_front_port_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "port": 80,
+                                                "httpListeners": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/httpListeners/176_http_listener_green"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/frontendPorts"
+                                        }
+                                    ],
+                                    "backendAddressPools": [
+                                        {
+                                            "name": "176_back_adr_pool_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/backendAddressPools/176_back_adr_pool_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "backendAddresses": [],
+                                                "requestRoutingRules": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/requestRoutingRules/176_routrule_green"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/backendAddressPools"
+                                        }
+                                    ],
+                                    "backendHttpSettingsCollection": [
+                                        {
+                                            "name": "176_back_http_set_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/backendHttpSettingsCollection/176_back_http_set_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "port": 80,
+                                                "protocol": "Http",
+                                                "cookieBasedAffinity": "Disabled",
+                                                "pickHostNameFromBackendAddress": false,
+                                                "path": "/path1/",
+                                                "requestTimeout": 60,
+                                                "requestRoutingRules": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/requestRoutingRules/176_routrule_green"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"
+                                        }
+                                    ],
+                                    "httpListeners": [
+                                        {
+                                            "name": "176_http_listener_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/httpListeners/176_http_listener_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "frontendIPConfiguration": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/frontendIPConfigurations/176_front_ip_conf_green"
+                                                },
+                                                "frontendPort": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/frontendPorts/176_front_port_green"
+                                                },
+                                                "protocol": "Http",
+                                                "hostNames": [],
+                                                "requireServerNameIndication": false,
+                                                "customErrorConfigurations": [],
+                                                "requestRoutingRules": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/requestRoutingRules/176_routrule_green"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/httpListeners"
+                                        }
+                                    ],
+                                    "urlPathMaps": [],
+                                    "requestRoutingRules": [
+                                        {
+                                            "name": "176_routrule_green",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/requestRoutingRules/176_routrule_green",
+                                            "etag": "W/\"28bae244-a4b7-408a-b0d9-03f67859a573\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "ruleType": "Basic",
+                                                "httpListener": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/httpListeners/176_http_listener_green"
+                                                },
+                                                "backendAddressPool": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/backendAddressPools/176_back_adr_pool_green"
+                                                },
+                                                "backendHttpSettings": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_green/providers/Microsoft.Network/applicationGateways/176_app_gateway_green/backendHttpSettingsCollection/176_back_http_set_green"
+                                                }
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/requestRoutingRules"
+                                        }
+                                    ],
+                                    "probes": [],
+                                    "rewriteRuleSets": [],
+                                    "redirectConfigurations": [],
+                                    "sslPolicy": {
+                                        "policyType": "Predefined",
+                                        "policyName": "AppGwSslPolicy20150501"
+                                    },
+                                    "enableHttp2": false,
+                                    "customErrorConfigurations": []
+                                }
+                            },
+                            {
+                                "name": "176_app_gateway_red",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red",
+                                "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                "type": "Microsoft.Network/applicationGateways",
+                                "location": "eastus",
+                                "tags": {
+                                    "ComplianceStatus": "Red",
+                                    "CustodianRule": "epam-azure-176-asb_ddos_protection_enabled"
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "424ffcf8-1378-4f1f-8fdb-940f5f5fd033",
+                                    "sku": {
+                                        "name": "Standard_Small",
+                                        "tier": "Standard",
+                                        "capacity": 2
+                                    },
+                                    "operationalState": "Running",
+                                    "gatewayIPConfigurations": [
+                                        {
+                                            "name": "176_gtw_ip_conf_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/gatewayIPConfigurations/176_gtw_ip_conf_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "subnet": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/virtualNetworks/176_vnet_red/subnets/appgtwgred"
+                                                }
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/gatewayIPConfigurations"
+                                        }
+                                    ],
+                                    "sslCertificates": [],
+                                    "authenticationCertificates": [],
+                                    "frontendIPConfigurations": [
+                                        {
+                                            "name": "176_front_ip_conf_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/frontendIPConfigurations/176_front_ip_conf_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "type": "Microsoft.Network/applicationGateways/frontendIPConfigurations",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "privateIPAllocationMethod": "Dynamic",
+                                                "publicIPAddress": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/publicIPAddresses/176_pip_red"
+                                                },
+                                                "httpListeners": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/httpListeners/176_http_listener_red"
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ],
+                                    "frontendPorts": [
+                                        {
+                                            "name": "176_front_port_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/frontendPorts/176_front_port_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "port": 80,
+                                                "httpListeners": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/httpListeners/176_http_listener_red"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/frontendPorts"
+                                        }
+                                    ],
+                                    "backendAddressPools": [
+                                        {
+                                            "name": "176_back_adr_pool_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/backendAddressPools/176_back_adr_pool_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "backendAddresses": [],
+                                                "requestRoutingRules": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/requestRoutingRules/176_routrule_red"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/backendAddressPools"
+                                        }
+                                    ],
+                                    "backendHttpSettingsCollection": [
+                                        {
+                                            "name": "176_back_http_set_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/backendHttpSettingsCollection/176_back_http_set_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "port": 80,
+                                                "protocol": "Http",
+                                                "cookieBasedAffinity": "Disabled",
+                                                "pickHostNameFromBackendAddress": false,
+                                                "path": "/path1/",
+                                                "requestTimeout": 60,
+                                                "requestRoutingRules": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/requestRoutingRules/176_routrule_red"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/backendHttpSettingsCollection"
+                                        }
+                                    ],
+                                    "httpListeners": [
+                                        {
+                                            "name": "176_http_listener_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/httpListeners/176_http_listener_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "frontendIPConfiguration": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/frontendIPConfigurations/176_front_ip_conf_red"
+                                                },
+                                                "frontendPort": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/frontendPorts/176_front_port_red"
+                                                },
+                                                "protocol": "Http",
+                                                "hostNames": [],
+                                                "requireServerNameIndication": false,
+                                                "customErrorConfigurations": [],
+                                                "requestRoutingRules": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/requestRoutingRules/176_routrule_red"
+                                                    }
+                                                ]
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/httpListeners"
+                                        }
+                                    ],
+                                    "urlPathMaps": [],
+                                    "requestRoutingRules": [
+                                        {
+                                            "name": "176_routrule_red",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/requestRoutingRules/176_routrule_red",
+                                            "etag": "W/\"8951eb70-f3bb-44cc-a134-e1c9700c786d\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "ruleType": "Basic",
+                                                "httpListener": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/httpListeners/176_http_listener_red"
+                                                },
+                                                "backendAddressPool": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/backendAddressPools/176_back_adr_pool_red"
+                                                },
+                                                "backendHttpSettings": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/176resource_group_red/providers/Microsoft.Network/applicationGateways/176_app_gateway_red/backendHttpSettingsCollection/176_back_http_set_red"
+                                                }
+                                            },
+                                            "type": "Microsoft.Network/applicationGateways/requestRoutingRules"
+                                        }
+                                    ],
+                                    "probes": [],
+                                    "rewriteRuleSets": [],
+                                    "redirectConfigurations": [],
+                                    "sslPolicy": {
+                                        "policyType": "Predefined",
+                                        "policyName": "AppGwSslPolicy20150501"
+                                    },
+                                    "enableHttp2": false,
+                                    "customErrorConfigurations": []
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SubnetApplicationGatewayTest.test_vnet_network_interface_assignment_filter.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SubnetApplicationGatewayTest.test_vnet_network_interface_assignment_filter.json
@@ -1,0 +1,341 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/virtualNetworks?api-version=2019-11-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "3746"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "a512882f-1ab6-4d10-a5c8-dc97856b83bd",
+                        "87ca5611-8ce2-4ed2-a5d5-98ac6982315e"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Mon, 27 Sep 2021 09:59:56 GMT"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "vnet1-141asbfwroute",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/virtualNetworks/vnet1-141asbfwroute",
+                                "etag": "W/\"c119d139-3f4f-4353-aacb-9eb9ba78226f\"",
+                                "type": "Microsoft.Network/virtualNetworks",
+                                "location": "eastus",
+                                "tags": {
+                                    "test": "Red"
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "d3026d29-b6fe-4877-b05b-b07cda6ed66b",
+                                    "addressSpace": {
+                                        "addressPrefixes": [
+                                            "10.0.0.0/16"
+                                        ]
+                                    },
+                                    "dhcpOptions": {
+                                        "dnsServers": []
+                                    },
+                                    "subnets": [
+                                        {
+                                            "name": "snet1-141asbfwroute",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/virtualNetworks/vnet1-141asbfwroute/subnets/snet1-141asbfwroute",
+                                            "etag": "W/\"c119d139-3f4f-4353-aacb-9eb9ba78226f\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "addressPrefix": "10.0.1.0/24",
+                                                "ipConfigurations": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/nic1141asbfwroute"
+                                                    }
+                                                ],
+                                                "serviceEndpoints": [],
+                                                "delegations": [],
+                                                "privateEndpointNetworkPolicies": "Enabled",
+                                                "privateLinkServiceNetworkPolicies": "Enabled"
+                                            },
+                                            "type": "Microsoft.Network/virtualNetworks/subnets"
+                                        }
+                                    ],
+                                    "virtualNetworkPeerings": [],
+                                    "enableDdosProtection": false
+                                }
+                            },
+                            {
+                                "name": "vnet2-141asbfwroute",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/virtualNetworks/vnet2-141asbfwroute",
+                                "etag": "W/\"0b294db5-0ff2-4622-acb8-91296d7350f4\"",
+                                "type": "Microsoft.Network/virtualNetworks",
+                                "location": "eastus",
+                                "tags": {
+                                    "test": "Red"
+                                },
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "7665e032-fbc2-48eb-a5f0-519b5111b348",
+                                    "addressSpace": {
+                                        "addressPrefixes": [
+                                            "10.0.0.0/16"
+                                        ]
+                                    },
+                                    "dhcpOptions": {
+                                        "dnsServers": []
+                                    },
+                                    "subnets": [
+                                        {
+                                            "name": "snet2-141asbfwroute",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/virtualNetworks/vnet2-141asbfwroute/subnets/snet2-141asbfwroute",
+                                            "etag": "W/\"0b294db5-0ff2-4622-acb8-91296d7350f4\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "addressPrefix": "10.0.2.0/24",
+                                                "ipConfigurations": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/networkInterfaces/nic2/ipConfigurations/nic2141asbfwroute"
+                                                    }
+                                                ],
+                                                "serviceEndpoints": [],
+                                                "delegations": [],
+                                                "privateEndpointNetworkPolicies": "Enabled",
+                                                "privateLinkServiceNetworkPolicies": "Enabled"
+                                            },
+                                            "type": "Microsoft.Network/virtualNetworks/subnets"
+                                        }
+                                    ],
+                                    "virtualNetworkPeerings": [],
+                                    "enableDdosProtection": false
+                                }
+                            },
+                            {
+                                "name": "TM-RM-vnet",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/virtualNetworks/TM-RM-vnet",
+                                "etag": "W/\"87f29c36-08f0-4b26-bea7-e58386563e17\"",
+                                "type": "Microsoft.Network/virtualNetworks",
+                                "location": "westeurope",
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "c3ea8c7f-6867-4666-9529-92923fa37be1",
+                                    "addressSpace": {
+                                        "addressPrefixes": [
+                                            "10.1.0.0/16"
+                                        ]
+                                    },
+                                    "subnets": [
+                                        {
+                                            "name": "default",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/virtualNetworks/TM-RM-vnet/subnets/default",
+                                            "etag": "W/\"87f29c36-08f0-4b26-bea7-e58386563e17\"",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "addressPrefix": "10.1.0.0/24",
+                                                "ipConfigurations": [
+                                                    {
+                                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/networkInterfaces/sasatm858/ipConfigurations/ipconfig1"
+                                                    }
+                                                ],
+                                                "delegations": [],
+                                                "privateEndpointNetworkPolicies": "Enabled",
+                                                "privateLinkServiceNetworkPolicies": "Enabled"
+                                            },
+                                            "type": "Microsoft.Network/virtualNetworks/subnets"
+                                        }
+                                    ],
+                                    "virtualNetworkPeerings": [],
+                                    "enableDdosProtection": false
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/networkInterfaces?api-version=2019-11-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "4671"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "8b338429-e2ab-4bde-ae9a-7ff023cf2838",
+                        "b2a299df-d4df-4e39-93a8-ba24079ecf13"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Mon, 27 Sep 2021 10:02:06 GMT"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "nic1",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/networkInterfaces/nic1",
+                                "etag": "W/\"55071466-0bb2-4c6b-a91c-d54e582661f9\"",
+                                "location": "eastus",
+                                "tags": {},
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "ceb5e398-3021-4a6a-9884-79951cbcc261",
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "nic1141asbfwroute",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/networkInterfaces/nic1/ipConfigurations/nic1141asbfwroute",
+                                            "etag": "W/\"55071466-0bb2-4c6b-a91c-d54e582661f9\"",
+                                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "privateIPAddress": "10.0.1.4",
+                                                "privateIPAllocationMethod": "Dynamic",
+                                                "subnet": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/virtualNetworks/vnet1-141asbfwroute/subnets/snet1-141asbfwroute"
+                                                },
+                                                "primary": true,
+                                                "privateIPAddressVersion": "IPv4"
+                                            }
+                                        }
+                                    ],
+                                    "dnsSettings": {
+                                        "dnsServers": [],
+                                        "appliedDnsServers": [],
+                                        "internalDomainNameSuffix": "ffwqfu54wz1urmc1wb4nu1wwnd.bx.internal.cloudapp.net"
+                                    },
+                                    "macAddress": "00-22-48-1E-72-FC",
+                                    "enableAcceleratedNetworking": false,
+                                    "enableIPForwarding": false,
+                                    "primary": true,
+                                    "virtualMachine": {
+                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Compute/virtualMachines/vm1-141asbfwroute"
+                                    },
+                                    "hostedWorkloads": [],
+                                    "tapConfigurations": []
+                                },
+                                "type": "Microsoft.Network/networkInterfaces"
+                            },
+                            {
+                                "name": "nic2",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/networkInterfaces/nic2",
+                                "etag": "W/\"507a694d-eb59-4e36-8921-20f02f507e3d\"",
+                                "location": "eastus",
+                                "tags": {},
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "44c2daaa-c8ee-49dd-be40-ef117e2ce3d1",
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "nic2141asbfwroute",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/networkInterfaces/nic2/ipConfigurations/nic2141asbfwroute",
+                                            "etag": "W/\"507a694d-eb59-4e36-8921-20f02f507e3d\"",
+                                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "privateIPAddress": "10.0.2.4",
+                                                "privateIPAllocationMethod": "Dynamic",
+                                                "subnet": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-141asbfwroute/providers/Microsoft.Network/virtualNetworks/vnet2-141asbfwroute/subnets/snet2-141asbfwroute"
+                                                },
+                                                "primary": true,
+                                                "privateIPAddressVersion": "IPv4"
+                                            }
+                                        }
+                                    ],
+                                    "dnsSettings": {
+                                        "dnsServers": [],
+                                        "appliedDnsServers": [],
+                                        "internalDomainNameSuffix": "glqgk3wc5pvurjpqkgnvcentja.bx.internal.cloudapp.net"
+                                    },
+                                    "enableAcceleratedNetworking": false,
+                                    "enableIPForwarding": false,
+                                    "hostedWorkloads": [],
+                                    "tapConfigurations": []
+                                },
+                                "type": "Microsoft.Network/networkInterfaces"
+                            },
+                            {
+                                "name": "sasatm858",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/networkInterfaces/sasatm858",
+                                "etag": "W/\"eb4fff64-4888-43f8-896a-1df714e9af67\"",
+                                "location": "westeurope",
+                                "properties": {
+                                    "provisioningState": "Succeeded",
+                                    "resourceGuid": "a567c308-21ef-4a45-bc7c-c19668093889",
+                                    "ipConfigurations": [
+                                        {
+                                            "name": "ipconfig1",
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/networkInterfaces/sasatm858/ipConfigurations/ipconfig1",
+                                            "etag": "W/\"eb4fff64-4888-43f8-896a-1df714e9af67\"",
+                                            "type": "Microsoft.Network/networkInterfaces/ipConfigurations",
+                                            "properties": {
+                                                "provisioningState": "Succeeded",
+                                                "privateIPAddress": "10.1.0.4",
+                                                "privateIPAllocationMethod": "Dynamic",
+                                                "publicIPAddress": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/publicIPAddresses/SasaTM-ip"
+                                                },
+                                                "subnet": {
+                                                    "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/virtualNetworks/TM-RM-vnet/subnets/default"
+                                                },
+                                                "primary": true,
+                                                "privateIPAddressVersion": "IPv4"
+                                            }
+                                        }
+                                    ],
+                                    "dnsSettings": {
+                                        "dnsServers": [],
+                                        "appliedDnsServers": [],
+                                        "internalDomainNameSuffix": "p4govq1hnbtenfjjskjd5i112b.ax.internal.cloudapp.net"
+                                    },
+                                    "macAddress": "60-45-BD-8E-1D-A1",
+                                    "enableAcceleratedNetworking": false,
+                                    "enableIPForwarding": false,
+                                    "networkSecurityGroup": {
+                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Network/networkSecurityGroups/SasaTM-nsg"
+                                    },
+                                    "primary": true,
+                                    "virtualMachine": {
+                                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TM-RM/providers/Microsoft.Compute/virtualMachines/SasaTM"
+                                    },
+                                    "hostedWorkloads": [],
+                                    "tapConfigurations": []
+                                },
+                                "type": "Microsoft.Network/networkInterfaces"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/SubscriptionDiagnosticSettingsFilterTest.test_subscription_activity_log_alerts.json
+++ b/tools/c7n_azure/tests_azure/cassettes/SubscriptionDiagnosticSettingsFilterTest.test_subscription_activity_log_alerts.json
@@ -1,0 +1,171 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/f7dc8823-4f06-4346-9de0-badbe6273a54?api-version=2019-11-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-length": [
+                        "403"
+                    ],
+                    "date": [
+                        "Mon, 27 Dec 2021 06:55:03 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47",
+                        "authorizationSource": "RoleBased",
+                        "managedByTenants": [],
+                        "subscriptionId": "ea42f556-5106-4743-99b0-c129bfa71a47",
+                        "tenantId": "00000000-0000-0000-0000-000000000003",
+                        "displayName": "Pay-As-You-Go-Student02",
+                        "state": "Enabled",
+                        "subscriptionPolicies": {
+                            "locationPlacementId": "Public_2014-09-01",
+                            "quotaId": "PayAsYouGo_2014-09-01",
+                            "spendingLimit": "Off"
+                        }
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/microsoft.insights/activityLogAlerts?api-version=2017-04-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "date": [
+                        "Mon, 27 Dec 2021 06:55:05 GMT"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "content-length": [
+                        "1619"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-039cisalertlog/providers/microsoft.insights/activityLogAlerts/green_alert-039cisalertlog",
+                                "type": "Microsoft.Insights/ActivityLogAlerts",
+                                "name": "green_alert-039cisalertlog",
+                                "location": "Global",
+                                "kind": null,
+                                "tags": {
+                                    "test": "Green"
+                                },
+                                "properties": {
+                                    "scopes": [
+                                        "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47"
+                                    ],
+                                    "condition": {
+                                        "allOf": [
+                                            {
+                                                "field": "category",
+                                                "equals": "Administrative",
+                                                "containsAny": null,
+                                                "odata.type": null
+                                            },
+                                            {
+                                                "field": "operationName",
+                                                "equals": "Microsoft.Authorization/policyAssignments/write",
+                                                "containsAny": null,
+                                                "odata.type": null
+                                            }
+                                        ],
+                                        "odata.type": null
+                                    },
+                                    "actions": {
+                                        "actionGroups": []
+                                    },
+                                    "enabled": true,
+                                    "description": ""
+                                },
+                                "identity": null
+                            },
+                            {
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-039cisalertlog/providers/microsoft.insights/activityLogAlerts/red_alert-039cisalertlog",
+                                "type": "Microsoft.Insights/ActivityLogAlerts",
+                                "name": "red_alert-039cisalertlog",
+                                "location": "Global",
+                                "kind": null,
+                                "tags": {
+                                    "test": "Red"
+                                },
+                                "properties": {
+                                    "scopes": [
+                                        "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/RG-039cisalertlog"
+                                    ],
+                                    "condition": {
+                                        "allOf": [
+                                            {
+                                                "field": "category",
+                                                "equals": "Administrative",
+                                                "containsAny": null,
+                                                "odata.type": null
+                                            },
+                                            {
+                                                "field": "operationName",
+                                                "equals": "Microsoft.Authorization/policyAssignments/write",
+                                                "containsAny": null,
+                                                "odata.type": null
+                                            },
+                                            {
+                                                "field": "level",
+                                                "equals": "Informational",
+                                                "containsAny": null,
+                                                "odata.type": null
+                                            },
+                                            {
+                                                "field": "status",
+                                                "equals": "Succeded",
+                                                "containsAny": null,
+                                                "odata.type": null
+                                            }
+                                        ],
+                                        "odata.type": null
+                                    },
+                                    "actions": {
+                                        "actionGroups": []
+                                    },
+                                    "enabled": false,
+                                    "description": ""
+                                },
+                                "identity": null
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/cassettes/TestJitPolicyFilter.test_query_jit_policy.json
+++ b/tools/c7n_azure/tests_azure/cassettes/TestJitPolicyFilter.test_query_jit_policy.json
@@ -1,0 +1,181 @@
+{
+    "version": 1,
+    "interactions": [
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2020-12-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "x-ms-ratelimit-remaining-resource": [
+                        "Microsoft.Compute/HighCostGet3Min;139,Microsoft.Compute/HighCostGet30Min;687"
+                    ],
+                    "date": [
+                        "Thu, 17 Feb 2022 14:13:44 GMT"
+                    ],
+                    "content-length": [
+                        "2880"
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "name": "dd2instance",
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Compute/virtualMachines/dd2instance",
+                                "type": "Microsoft.Compute/virtualMachines",
+                                "location": "eastus",
+                                "properties": {
+                                    "vmId": "58da85b5-87d2-4e2b-b582-52c8e7c25f92",
+                                    "hardwareProfile": {
+                                        "vmSize": "Standard_B2s"
+                                    },
+                                    "storageProfile": {
+                                        "imageReference": {
+                                            "publisher": "Canonical",
+                                            "offer": "UbuntuServer",
+                                            "sku": "18_04-lts-gen2",
+                                            "version": "latest",
+                                            "exactVersion": "18.04.202201180"
+                                        },
+                                        "osDisk": {
+                                            "osType": "Linux",
+                                            "name": "dd2instance_OsDisk_1_035fa0d359d84792b773f9d6f9a81edb",
+                                            "createOption": "FromImage",
+                                            "caching": "ReadWrite",
+                                            "managedDisk": {
+                                                "storageAccountType": "StandardSSD_LRS",
+                                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Compute/disks/dd2instance_OsDisk_1_035fa0d359d84792b773f9d6f9a81edb"
+                                            },
+                                            "diskSizeGB": 30
+                                        },
+                                        "dataDisks": []
+                                    },
+                                    "osProfile": {
+                                        "computerName": "dd2instance",
+                                        "adminUsername": "ddsuperuser",
+                                        "linuxConfiguration": {
+                                            "disablePasswordAuthentication": true,
+                                            "ssh": {
+                                                "publicKeys": [
+                                                    {
+                                                        "path": "/home/ddsuperuser/.ssh/authorized_keys",
+                                                        "keyData": "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCovx2czQGUi+RDibC5oWJtKCWz\r\nYyvKIjgYtSVEOxLMjtfCJRDCUWT8q3Y/arc3YLLQqGnACDIdaE9Nt6N1EDFqLOQw\r\nbta9lK6ahft8FDGQ89YFcp66GViPdI9LrktfKnrkwxbr/ob0LCv9k0goTMzxNkV9\r\nH0jeQsDtdQLRafEqTAURrEtRwhh+ZrRelcDaoWUjVGqH61eOnNQujILxsx4ZoaIL\r\ni9+MKTSCpl8YPvORBqgjRcA1oAMUtetpC2WA/Ea+hVV0dSu1QH8soQNpzH53Q661\r\n8sSR/V4Swgsj//lhgdN29rI96f2p3lUa1quP1JJVNoh8qyuviyu6T5lC763pkTbi\r\n5s27veZW8G8zznO2SMtoKVwN/PVHNZcUm4e96SiGD277WP3AYZ49bmRJCzJvjtGJ\r\nik1kR5yvmFq7seyoBV1Gbzui8qEge4AzxO7R462MSgUCRC+U1FujX8VxRPNrHd5T\r\nVtkj3IcuHY2mxxqrzlK7omrxFPVUmDi+To5JCbk= generated-by-azure\r\n"
+                                                    }
+                                                ]
+                                            },
+                                            "provisionVMAgent": true,
+                                            "patchSettings": {
+                                                "patchMode": "ImageDefault"
+                                            }
+                                        },
+                                        "secrets": [],
+                                        "allowExtensionOperations": true,
+                                        "requireGuestProvisionSignal": true
+                                    },
+                                    "networkProfile": {
+                                        "networkInterfaces": [
+                                            {
+                                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Network/networkInterfaces/dd2instance380",
+                                                "properties": {
+                                                    "deleteOption": "Detach"
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "provisioningState": "Succeeded"
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        {
+            "request": {
+                "method": "GET",
+                "uri": "https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Security/jitNetworkAccessPolicies?api-version=2020-01-01",
+                "body": null,
+                "headers": {}
+            },
+            "response": {
+                "status": {
+                    "code": 200,
+                    "message": "OK"
+                },
+                "headers": {
+                    "content-length": [
+                        "731"
+                    ],
+                    "cache-control": [
+                        "no-cache"
+                    ],
+                    "content-type": [
+                        "application/json; charset=utf-8"
+                    ],
+                    "date": [
+                        "Thu, 17 Feb 2022 14:13:45 GMT"
+                    ],
+                    "x-ms-ratelimit-remaining-subscription-resource-requests": [
+                        "749"
+                    ],
+                    "x-ms-original-request-ids": [
+                        "",
+                        "",
+                        ""
+                    ]
+                },
+                "body": {
+                    "data": {
+                        "value": [
+                            {
+                                "kind": "Basic",
+                                "properties": {
+                                    "virtualMachines": [
+                                        {
+                                            "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Compute/virtualMachines/dd2instance",
+                                            "ports": [
+                                                {
+                                                    "number": 22,
+                                                    "protocol": "*",
+                                                    "allowedSourceAddressPrefix": "*",
+                                                    "maxRequestAccessDuration": "PT3H"
+                                                },
+                                                {
+                                                    "number": 3389,
+                                                    "protocol": "*",
+                                                    "allowedSourceAddressPrefix": "*",
+                                                    "maxRequestAccessDuration": "PT3H"
+                                                }
+                                            ]
+                                        }
+                                    ],
+                                    "requests": [],
+                                    "provisioningState": "Succeeded",
+                                    "appendMode": false
+                                },
+                                "id": "/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/VV/providers/Microsoft.Security/locations/eastus/jitNetworkAccessPolicies/dd2instance",
+                                "name": "dd2instance",
+                                "type": "Microsoft.Security/locations/jitNetworkAccessPolicies",
+                                "location": "eastus"
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/tools/c7n_azure/tests_azure/tests_resources/test_sqlmanagedinstance.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_sqlmanagedinstance.py
@@ -1,0 +1,84 @@
+from ..azure_common import BaseTest
+
+
+class SqlManagedInstanceTest(BaseTest):
+
+    def test_sql_managed_instance_schema_validate(self):
+        p = self.load_policy({
+            'name': 'test-policy-assignment',
+            'resource': 'azure.sql-managed-instance'
+        }, validate=True)
+        self.assertTrue(p)
+
+        # test alias for back-compatibility
+        p = self.load_policy({
+            'name': 'test-policy-assignment',
+            'resource': 'azure.sqlmanagedinstance'
+        }, validate=True)
+        self.assertTrue(p)
+
+    def test_sql_managed_instance(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-all',
+            'resource': 'azure.sql-managed-instance',
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('vvtestmisql', resources[0]['name'])
+
+    def test_sql_managed_instance_security_alert_policies(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-filter-security-alert-policy',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [{
+                'type': 'value',
+                'key': 'properties.state',
+                'value': 'Ready'
+            }]
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('vvtestmisql', resources[0]['name'])
+        self.assertEqual('Ready', resources[0]['properties']['state'])
+
+    def test_sql_managed_server_security_alert_policies(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-server-filter-security-alert-policy',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [{
+                'type': 'managed-server-security-alert-policies',
+                'key': 'state',
+                'value': 'Disabled'
+            }]
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('vvsqlmi1', resources[0]['name'])
+
+    def test_filter_recurring_scans(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-recurring-scan-disabled',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [
+                {'type': 'vulnerability-assessments',
+                 'key': 'recurring_scans.is_enabled',
+                 'value': 'True'
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('testsqlmi71', resources[0]['name'])
+
+    def test_filter_encryption_protector(self):
+        p = self.load_policy({
+            'name': 'test-azure-sql-managed-instance-service-managed',
+            'resource': 'azure.sql-managed-instance',
+            'filters': [
+                {'type': 'encryption-protector',
+                 'key': 'kind',
+                 'value': 'servicemanaged'
+                 }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('testsqlmi71', resources[0]['name'])

--- a/tools/c7n_azure/tests_azure/tests_resources/test_subscription.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_subscription.py
@@ -104,3 +104,24 @@ class SubscriptionDiagnosticSettingsFilterTest(BaseTest):
         }, validate=True)
 
         self.assertEqual(0, len(p.run()))
+
+    def test_subscription_activity_log_alerts(self):
+        p = self.load_policy({
+            'name': 'test-subscription-activity-log-alerts',
+            'resource': 'azure.subscription',
+            'filters': [{
+                'type': 'activity-log-alert',
+                'key': "length(alerts[?location=='Global' " +
+                       " && condition.all_of[" +
+                       "?(field=='operationName'" +
+                       " && equals=='Microsoft.Authorization/policyAssignments/write')]" +
+                       " && length(condition.all_of[" +
+                       "?(field=='level' || field=='status' || field=='caller') " +
+                       "|| contains(keys(@), 'containsAny')])==`0`])",
+                'value': 0,
+                'op': 'gt'
+            }],
+        })
+        resources = p.run()
+        self.assertEqual(1, len(resources))
+        self.assertEqual('ea42f556-5106-4743-99b0-c129bfa71a47', resources[0]['subscriptionId'])

--- a/tools/c7n_azure/tests_azure/tests_resources/test_vm.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_vm.py
@@ -12,6 +12,20 @@ from c7n.testing import mock_datetime_now
 from c7n.utils import local_session
 
 
+class TestJitPolicyFilter(BaseTest):
+    def test_query_jit_policy(self):
+        p = self.load_policy({
+            'name': 'jit-policy',
+            'resource': 'azure.vm',
+            'filters': [{'not': [
+                {'type': 'security-jit-policy'}]}]
+        })
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual('dd2instance', resources[0]['name'])
+
+
 class VMTest(BaseTest):
     def setUp(self):
         super(VMTest, self).setUp()

--- a/tools/c7n_azure/tests_azure/tests_resources/test_vnet.py
+++ b/tools/c7n_azure/tests_azure/tests_resources/test_vnet.py
@@ -1,0 +1,46 @@
+from ..azure_common import BaseTest
+
+
+class SubnetApplicationGatewayTest(BaseTest):
+
+    def test_subnet_application_gateway_filter(self):
+        p = self.load_policy(
+            {
+                "name": "test-subnet-application-gateway-filter",
+                "resource": "azure.vnet",
+                "filters": [
+                    {
+                        "type": "subnet-application-gateway-vnet-filter"},
+                    {
+                        "type": "value",
+                        "key": "properties.ddosProtectionPlan.id",
+                        "value": r"\/.+\/ddosProtectionPlans\/.+",
+                        "op": "regex",
+                    },
+                    {
+                        "type": "value",
+                        "key": "properties.enableDdosProtection",
+                        "value": True,
+                    }
+                ],
+            }
+        )
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+
+    def test_vnet_network_interface_assignment_filter(self):
+        p = self.load_policy({
+            "name": "test-vnet-network-interface-assignment-filter",
+            "resource": "azure.vnet",
+            "filters": [{
+                "type": "network-interface-assignment",
+                "key": "virtual_machine",
+                "value": "present"
+            }]
+        })
+        resources = p.run()
+
+        self.assertEqual(2, len(resources))
+        self.assertEqual('vnet1-141asbfwroute', resources[0]['name'])
+        self.assertEqual('TM-RM-vnet', resources[1]['name'])


### PR DESCRIPTION
Moved:
- `azure.subscription.activity-log-alert` (045, 373, 374, 044, 039, 043, 068, 067, 042, 066, 046)
- `azure.sql-managed-instance.filters` (196, 207, 265)
- `azure.disk.snapshots` (139)
- `azure.vnet.filters` (176, 141)
- `azure.vm.security-jit-policy` (152)